### PR TITLE
Upgraded RuboCop, closes #7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: ruby
 
+sudo: false
+
 cache: bundler
 
 rvm:
+  - 2.5.0
+  - 2.4.3
+  - 2.3.6
+  - 2.2.9
+  - 2.1.10
   - ruby-head
-  - 2.1.7
-  - 2.0.0
-  - 1.9.3
-  - jruby-19mode
   - jruby-head
-  - rbx-2
+  - rbx-3
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-
-sudo: false
+    - rvm: rbx-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 0.1.2 (Next)
+### 0.2.0 (Next)
 
+* [#9](https://github.com/Maxim-Filimonov/hashie-forbidden_attributes/pull/9): Dropped support for Ruby < 2.1 - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
-gem 'rubocop', '0.22.0'
+gem 'rubocop', '0.54.0'

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 require 'rubocop/rake_task'
-Rubocop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop)
 
 task :migrate_db do
   Dir.chdir('test/dummy') do
@@ -26,4 +26,4 @@ end
 
 task test: :migrate_db
 
-task default: [:rubocop, :test]
+task default: %i[rubocop test]

--- a/hashie-forbidden_attributes.gemspec
+++ b/hashie-forbidden_attributes.gemspec
@@ -1,4 +1,4 @@
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 require 'hashie-forbidden_attributes/version'
 
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM != 'java'
     s.add_development_dependency 'sqlite3'
   else
-    s.add_development_dependency 'jdbc-sqlite3'
     s.add_development_dependency 'activerecord-jdbcsqlite3-adapter'
+    s.add_development_dependency 'jdbc-sqlite3'
   end
 
+  s.add_development_dependency 'grape'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rails', '~> 4.0'
-  s.add_development_dependency 'grape'
 end

--- a/lib/hashie-forbidden_attributes/hashie/mash.rb
+++ b/lib/hashie-forbidden_attributes/hashie/mash.rb
@@ -2,17 +2,14 @@ require 'hashie/mash'
 
 module Hashie
   class Mash
-    alias_method :_respond_to_missing?, :respond_to_missing?
-    alias_method :_method_missing, :method_missing
-
     def respond_to_missing?(method_name, *args)
       return false if method_name == :permitted?
-      _respond_to_missing?(method_name, args)
+      super
     end
 
     def method_missing(method_name, *args)
-      fail ArgumentError if method_name == :permitted?
-      _method_missing(method_name, *args)
+      raise ArgumentError if method_name == :permitted?
+      super
     end
   end
 end

--- a/lib/hashie-forbidden_attributes/version.rb
+++ b/lib/hashie-forbidden_attributes/version.rb
@@ -1,3 +1,3 @@
 module HashieForbiddenAttributes
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
-require File.expand_path('../dummy/config/environment.rb',  __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 require 'rails/test_help'
 
 Rails.backtrace_cleaner.remove_silencers!
@@ -11,5 +11,5 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.method_defined?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path('../fixtures', __FILE__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path('fixtures', __dir__)
 end


### PR DESCRIPTION
Replaces https://github.com/Maxim-Filimonov/hashie-forbidden_attributes/pull/8

I copied the build matrix from current Hashie, so no more Ruby 1.9.3. Did a major version bump.